### PR TITLE
Example OAuth Provider implemented as MM plugin

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -20,7 +20,7 @@
         "footer": "",
         "settings": [
             {
-                "key": "ExpectedClientId",
+                "key": "ExpectedClientID",
                 "display_name": "Expected Client Id:",
                 "type": "text",
                 "help_text": "",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
-    "id": "com.mattermost.plugin-starter-template",
-    "name": "Plugin Starter Template",
-    "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
+    "id": "oauth-provider-example",
+    "name": "Example OAuth Provider",
+    "description": "This plugin helps streamline testing of the Outgoing OAuth Connections feature",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",
     "support_url": "https://github.com/mattermost/mattermost-plugin-starter-template/issues",
     "icon_path": "assets/starter-template-icon.svg",
@@ -18,6 +18,31 @@
     "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+            {
+                "key": "ExpectedClientId",
+                "display_name": "Expected Client Id:",
+                "type": "text",
+                "help_text": "",
+                "placeholder": "",
+                "default": "example_client_id"
+            },
+            {
+                "key": "ExpectedClientSecret",
+                "display_name": "Expected Client Secret:",
+                "type": "text",
+                "help_text": "",
+                "placeholder": "",
+                "default": "example_client_secret"
+            },
+            {
+                "key": "AccessToken",
+                "display_name": "Access Token to return:",
+                "type": "text",
+                "help_text": "",
+                "placeholder": "",
+                "default": "example_access_token"
+            }
+        ]
     }
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -6,30 +6,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// configuration captures the plugin's external configuration as exposed in the Mattermost server
-// configuration, as well as values computed from the configuration. Any public fields will be
-// deserialized from the Mattermost server configuration in OnConfigurationChange.
-//
-// As plugins are inherently concurrent (hooks being called asynchronously), and the plugin
-// configuration can change at any time, access to the configuration must be synchronized. The
-// strategy used in this plugin is to guard a pointer to the configuration, and clone the entire
-// struct whenever it changes. You may replace this with whatever strategy you choose.
-//
-// If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
-// copy appropriate for your types.
 type configuration struct {
+	ExpectedClientId     string
+	ExpectedClientSecret string
+	AccessToken          string
 }
 
-// Clone shallow copies the configuration. Your implementation may require a deep copy if
-// your configuration has reference types.
 func (c *configuration) Clone() *configuration {
 	var clone = *c
 	return &clone
 }
 
-// getConfiguration retrieves the active configuration under lock, making it safe to use
-// concurrently. The active configuration may change underneath the client of this method, but
-// the struct returned by this API call is considered immutable.
 func (p *Plugin) getConfiguration() *configuration {
 	p.configurationLock.RLock()
 	defer p.configurationLock.RUnlock()
@@ -41,23 +28,11 @@ func (p *Plugin) getConfiguration() *configuration {
 	return p.configuration
 }
 
-// setConfiguration replaces the active configuration under lock.
-//
-// Do not call setConfiguration while holding the configurationLock, as sync.Mutex is not
-// reentrant. In particular, avoid using the plugin API entirely, as this may in turn trigger a
-// hook back into the plugin. If that hook attempts to acquire this lock, a deadlock may occur.
-//
-// This method panics if setConfiguration is called with the existing configuration. This almost
-// certainly means that the configuration was modified without being cloned and may result in
-// an unsafe access.
 func (p *Plugin) setConfiguration(configuration *configuration) {
 	p.configurationLock.Lock()
 	defer p.configurationLock.Unlock()
 
 	if configuration != nil && p.configuration == configuration {
-		// Ignore assignment if the configuration struct is empty. Go will optimize the
-		// allocation for same to point at the same memory address, breaking the check
-		// above.
 		if reflect.ValueOf(*configuration).NumField() == 0 {
 			return
 		}
@@ -68,11 +43,9 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 	p.configuration = configuration
 }
 
-// OnConfigurationChange is invoked when configuration changes may have been made.
 func (p *Plugin) OnConfigurationChange() error {
 	var configuration = new(configuration)
 
-	// Load the public configuration fields from the Mattermost server configuration.
 	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -7,7 +7,7 @@ import (
 )
 
 type configuration struct {
-	ExpectedClientId     string
+	ExpectedClientID     string
 	ExpectedClientSecret string
 	AccessToken          string
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -89,13 +89,13 @@ func (p *Plugin) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 
-	r.ParseForm()
+	_ = r.ParseForm()
 
-	clientId := r.Form.Get("client_id")
+	clientID := r.Form.Get("client_id")
 	clientSecret := r.Form.Get("client_secret")
 	grantType := r.Form.Get("grant_type")
 
-	if clientId != conf.ExpectedClientId {
+	if clientID != conf.ExpectedClientID {
 		http.Error(w, `{"error": "Invalid value for client id"}`, http.StatusBadRequest)
 		return
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,28 +1,93 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 )
 
-// Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
 type Plugin struct {
 	plugin.MattermostPlugin
 
-	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
 
-	// configuration is the active plugin configuration. Consult getConfiguration and
-	// setConfiguration for usage.
 	configuration *configuration
 }
 
-// ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello, world!")
+	switch r.URL.Path {
+	case "/token":
+		p.handleTokenRequest(w, r)
+	case "/command":
+		p.handleCommandRequest(w, r)
+	case "/webhook":
+		p.handleWebhookRequest(w, r)
+	default:
+		handleNotFound(w, r)
+	}
+}
+
+func (p *Plugin) handleWebhookRequest(w http.ResponseWriter, r *http.Request) {
+	webhookResponse := model.OutgoingWebhookResponse{
+		Text: model.NewString("called the webhook"),
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	err := json.NewEncoder(w).Encode(webhookResponse)
+	if err != nil {
+		p.API.LogError("failed to marshal webhook response", "err", err.Error())
+	}
+}
+
+func (p *Plugin) handleCommandRequest(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	parts := strings.Split(authHeader, " ")
+	tokenType, accessToken := parts[0], parts[1]
+
+	msg := fmt.Sprintf("token type: '%s' access token: '%s'", tokenType, accessToken)
+
+	// TODO make a plugin setting and verify token matches here
+
+	commandResponse := model.CommandResponse{
+		Text:         msg,
+		ResponseType: model.CommandResponseTypeEphemeral,
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	err := json.NewEncoder(w).Encode(commandResponse)
+	if err != nil {
+		p.API.LogError("failed to marshal command response", "err", err.Error())
+	}
+}
+
+func (p *Plugin) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
+	conf := p.getConfiguration()
+
+	tokenResponse := TokenResponse{
+		AccessToken: conf.AccessToken,
+		TokenType:   "Bearer",
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	err := json.NewEncoder(w).Encode(tokenResponse)
+	if err != nil {
+		p.API.LogError("failed to marshal token response", "err", err.Error())
+	}
+}
+
+func handleNotFound(w http.ResponseWriter, r *http.Request) {
+	msg := fmt.Sprintf("OAuth Example plugin does not handle the path `%s`", r.URL.Path)
+	http.Error(w, msg, http.StatusNotFound)
 }
 
 // See https://developers.mattermost.com/extend/plugins/server/reference/

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -24,5 +24,5 @@ func TestServeHTTP(t *testing.T) {
 	assert.Nil(err)
 	bodyString := string(bodyBytes)
 
-	assert.Equal("Hello, world!", bodyString)
+	assert.Equal("OAuth Example plugin does not handle the path `/`\n", bodyString)
 }


### PR DESCRIPTION
This plugin implements 3 http endpoints to be used for testing the Outgoing OAuth Connections feature

- `/token` - Accepts `client_id` and `client_secret` as URL encoded values, and returns a token
- `/command` - Accepts command submission, and returns text containing the supplied token
- `/webhook` - Accepts an outgoing webhook submission